### PR TITLE
Added 'DependsOn: "LogsBucketPolicy"' to AWSEBLoadBalancer for ELB logging

### DIFF
--- a/.ebextensions/aws_provided/resource configuration/loadbalancer-accesslogs-newbucket.config
+++ b/.ebextensions/aws_provided/resource configuration/loadbalancer-accesslogs-newbucket.config
@@ -50,6 +50,7 @@ Resources:
         S3BucketName: 
           Ref: LogsBucket
     Type: "AWS::ElasticLoadBalancing::LoadBalancer"
+    DependsOn: "LogsBucketPolicy"
 
   LogsBucket: 
     DeletionPolicy: Retain


### PR DESCRIPTION
Configuring logging for an ELB will sometimes fail if the bucket policy is not created by the time the logging is configured in CFN. Adding a "DependsOn" resolves this issue.