### PR TITLE
Add config to remove unused docker container/images

### DIFF
--- a/.ebextensions/aws_provided/instance configuration/docker-remove-unused-containers-and-images.config
+++ b/.ebextensions/aws_provided/instance configuration/docker-remove-unused-containers-and-images.config
@@ -1,0 +1,12 @@
+files:
+  "/opt/elasticbeanstalk/hooks/appdeploy/post/99-docker-cleanup.sh":
+    mode: "000755"
+    owner: root
+    group: root
+    content: |
+      #!/usr/bin/env bash
+      # remove all stopped containers
+      docker rm $(docker ps -a -q)
+      # remove all unused images
+      docker images -q | while read line; do docker rmi $line 2>/dev/null; done
+      exit 0


### PR DESCRIPTION
This hook script is useful to clean up unused docker container/images at every EB deploy