### PR TITLE
Fixed parameter type

### DIFF
--- a/.ebextensions/aws_provided/resource configuration/loadbalancer-accesslogs-existingbucket.config
+++ b/.ebextensions/aws_provided/resource configuration/loadbalancer-accesslogs-existingbucket.config
@@ -12,15 +12,15 @@
 ###################################################################################################
 
 ###################################################################################################
-#### The following parameter configures a bucket name for the storage of access logs from the load 
+#### The following parameter configures a bucket name for the storage of access logs from the load
 #### balancer. The load balancer must have permission to upload logs to the bucket.
-#### See the following topic for instructions: 
+#### See the following topic for instructions:
 #### http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/enable-access-logs.html
 ###################################################################################################
 
 Parameters:
-  bucket: 
-    Type: CommaDelimitedList
+  bucket:
+    Type: String
     Description: "Name of the Amazon S3 bucket in which to store load balancer logs"
     Default: "elasticbeanstalk-region-accountid"
 


### PR DESCRIPTION
The "bucket" parameter was defined as a CommaDelimitedList, which resulted in the following error when applying the .ebextension to an environment:

```
  ERROR: Updating load balancer named: awseb-e-d-AWSEBLoa-XXXXXXXXXXXXX failed Reason: Value of property S3BucketName must be of type String
```

S3BucketName parameter of the access logging policy is expected to be a String: [docs](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-elb-accessloggingpolicy.html#cfn-elb-accessloggingpolicy-s3bucketname).