### PR TITLE
Add passenger_enabled deployment option

### DIFF
--- a/.ebextensions/aws_provided/security configuration/https-redirect-load-balanced-ruby-passenger/https-redirect-ruby-passenger.config
+++ b/.ebextensions/aws_provided/security configuration/https-redirect-load-balanced-ruby-passenger/https-redirect-ruby-passenger.config
@@ -168,7 +168,8 @@ files:
                   }
                   if ($redirect = 1) {
                     return 301 https://$host$request_uri;
-                  }   
+                  }
+                  passenger_enabled on;
               }
 
               # Rails asset pipeline support.


### PR DESCRIPTION
This should be added, otherwise the redirect is served from nginx instead of passenger