### PR TITLE
Add a new .ebextension for Redshift Java-based SSL via JDBC

### DIFF
--- a/configuration-files/aws-provided/security-configuration/README.md
+++ b/configuration-files/aws-provided/security-configuration/README.md
@@ -12,6 +12,9 @@ Modify your instance's security group to allow HTTPS traffic on port 443. Use in
 ### rds-ssl-java.config
 Install SSL certificates for RDS database connections with JDBC.
 
+### redshift-ssl-java.config
+Install SSL certificates for Redshift database connections with JDBC.
+
 ### securitygroup-addexisting.config
 Configure the Auto Scaling Group to launch EC2 instances with an existing Security Group. This is an additional Security Group to the one automatically created by Elastic Beanstalk for the EC2 instances. Useful when configuring a database's instance Security Group to only accept connections from a specific source Security Group of your Elastic Beanstalk environment's instances.
 

--- a/configuration-files/aws-provided/security-configuration/redshift-ssl-java.config
+++ b/configuration-files/aws-provided/security-configuration/redshift-ssl-java.config
@@ -1,0 +1,70 @@
+###################################################################################################
+#### Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+####
+#### Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+#### except in compliance with the License. A copy of the License is located at
+####
+####     http://aws.amazon.com/apache2.0/
+####
+#### or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+#### BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#### License for the specific language governing permissions and limitations under the License.
+###################################################################################################
+
+###################################################################################################
+#### This configuration file installs the SSL intermediate and root certificates for
+#### Redshift into the root Java installation so that your Java Tomcat Elastic Beanstalk
+#### can securely talk to a Redshift database over SSL using standard JDBC mechanisms.
+####
+#### For more details, see:
+#### https://docs.aws.amazon.com/redshift/latest/mgmt/connecting-ssl-support.html
+###################################################################################################
+
+##############################################
+#### Do not modify values below this line ####
+##############################################
+
+commands:
+  01_install:
+    command: "/tmp/install-redshift-ssl-cert.sh"
+
+files:
+  "/tmp/install-redshift-ssl-cert.sh":
+      mode: "000755"
+      content : |
+        #!/bin/bash
+
+        REDSHIFT_ROOT_ALIAS="redshift_root"
+        REDSHIFT_ROOT_LOCAL_FILE="/tmp/redshift-ssl-ca-cert.pem"
+        JAVA_KEYSTORE_PASSWORD="changeit"
+
+        #via https://docs.aws.amazon.com/redshift/latest/mgmt/connecting-ssl-support.html
+        ROOT_REDSHIFT_CERT_URL="https://s3.amazonaws.com/redshift-downloads/redshift-ssl-ca-cert.pem"
+
+        if [ -z "$JAVA_HOME" ]; then
+                echo "JAVA_HOME was not set. Setting to default of /usr/lib/jvm/jre..."
+                export JAVA_HOME=/usr/lib/jvm/jre
+        fi
+
+        JAVA_KEYSTORE_FILE="$JAVA_HOME/lib/security/cacerts"
+
+        echo "Attempting to remove any previously installed Redshift SSL certificate (and ignoring errors)..."
+
+        $JAVA_HOME/bin/keytool -delete -alias $REDSHIFT_ROOT_ALIAS -storepass $JAVA_KEYSTORE_PASSWORD -noprompt -keystore $JAVA_KEYSTORE_FILE
+
+        echo "Downloading ${ROOT_REDSHIFT_CERT_URL}..."
+        curl $ROOT_REDSHIFT_CERT_URL > $REDSHIFT_ROOT_LOCAL_FILE
+        if [ $? -ne 0 ]; then
+                echo "ERROR: Could not download Redshift root certificate!"
+                exit 1
+        fi
+
+        #Installing new cert to the keystore requires root permissions
+        echo 'Installing downloaded Redshift certificate into the Java keystore...'
+
+        $JAVA_HOME/bin/keytool -import -alias $REDSHIFT_ROOT_ALIAS -storepass $JAVA_KEYSTORE_PASSWORD -noprompt -keystore $JAVA_KEYSTORE_FILE -file $REDSHIFT_ROOT_LOCAL_FILE
+        if [ $? -ne 0 ]; then
+                echo "ERROR: Could not install Redshift root certificate!"
+                exit 1
+        fi
+        echo 'Redshift root certificate installed successfully!'


### PR DESCRIPTION
This is heavily modeled on the existing rds-ssl-java.config, but it's slightly simpler because Redshift only needs to install a single root certificate rather than the root and regional certificates required for RDS.