### PR TITLE
Fix wrong indent level of yaml config

### DIFF
--- a/configuration-files/aws-provided/resource-configuration/autoscaling-triggers-disabledefault.config
+++ b/configuration-files/aws-provided/resource-configuration/autoscaling-triggers-disabledefault.config
@@ -21,8 +21,8 @@ Resources:
    AWSEBCloudwatchAlarmHigh:
      Type: AWS::CloudWatch::Alarm
      Properties:
-     AlarmActions: [ { "Ref" : "AWS::NoValue" } ]
+       AlarmActions: [ { "Ref" : "AWS::NoValue" } ]
    AWSEBCloudwatchAlarmLow:
      Type: AWS::CloudWatch::Alarm
      Properties:
-     AlarmActions: [ { "Ref" : "AWS::NoValue" } ]
+       AlarmActions: [ { "Ref" : "AWS::NoValue" } ]


### PR DESCRIPTION
This is not document level typo just a bug because cannot use this config in beanstalk project.

Caused error events in beanstalk console.

```
2017-06-12 11:19:57 UTC+0900	ERROR	Failed to deploy application.
2017-06-12 11:19:56 UTC+0900	ERROR	InvalidParameterValue: Template does not have a numeric EvaluationPeriods setting
2017-06-12 11:19:51 UTC+0900	INFO	Environment update is starting.
```