### PR TITLE
Update Redshift Java SSL .ebextension to use new Redshift certificate bundle

### DIFF
--- a/configuration-files/aws-provided/security-configuration/redshift-ssl-java.config
+++ b/configuration-files/aws-provided/security-configuration/redshift-ssl-java.config
@@ -12,12 +12,13 @@
 ###################################################################################################
 
 ###################################################################################################
-#### This configuration file installs the SSL intermediate and root certificates for
+#### This configuration file installs the SSL certificate bundle for
 #### Redshift into the root Java installation so that your Java Tomcat Elastic Beanstalk
 #### can securely talk to a Redshift database over SSL using standard JDBC mechanisms.
 ####
 #### For more details, see:
 #### https://docs.aws.amazon.com/redshift/latest/mgmt/connecting-ssl-support.html
+#### https://docs.aws.amazon.com/redshift/latest/mgmt/connecting-transitioning-to-acm-certs.html
 ###################################################################################################
 
 ##############################################
@@ -26,20 +27,20 @@
 
 commands:
   01_install:
-    command: "/tmp/install-redshift-ssl-cert.sh"
+    command: "/tmp/install-redshift-ssl-cert-bundle.sh"
 
 files:
-  "/tmp/install-redshift-ssl-cert.sh":
+  "/tmp/install-redshift-ssl-cert-bundle.sh":
       mode: "000755"
       content : |
         #!/bin/bash
 
-        REDSHIFT_ROOT_ALIAS="redshift_root"
-        REDSHIFT_ROOT_LOCAL_FILE="/tmp/redshift-ssl-ca-cert.pem"
+        REDSHIFT_ROOT_ALIAS="redshift_bundle"
+        REDSHIFT_ROOT_LOCAL_FILE="/tmp/redshift-ssl-ca-bundle.crt"
         JAVA_KEYSTORE_PASSWORD="changeit"
 
         #via https://docs.aws.amazon.com/redshift/latest/mgmt/connecting-ssl-support.html
-        ROOT_REDSHIFT_CERT_URL="https://s3.amazonaws.com/redshift-downloads/redshift-ssl-ca-cert.pem"
+        ROOT_REDSHIFT_CERT_URL="https://s3.amazonaws.com/redshift-downloads/redshift-ca-bundle.crt"
 
         if [ -z "$JAVA_HOME" ]; then
                 echo "JAVA_HOME was not set. Setting to default of /usr/lib/jvm/jre..."
@@ -55,16 +56,16 @@ files:
         echo "Downloading ${ROOT_REDSHIFT_CERT_URL}..."
         curl $ROOT_REDSHIFT_CERT_URL > $REDSHIFT_ROOT_LOCAL_FILE
         if [ $? -ne 0 ]; then
-                echo "ERROR: Could not download Redshift root certificate!"
+                echo "ERROR: Could not download Redshift certificate bundle!"
                 exit 1
         fi
 
         #Installing new cert to the keystore requires root permissions
         echo 'Installing downloaded Redshift certificate into the Java keystore...'
 
-        $JAVA_HOME/bin/keytool -import -alias $REDSHIFT_ROOT_ALIAS -storepass $JAVA_KEYSTORE_PASSWORD -noprompt -keystore $JAVA_KEYSTORE_FILE -file $REDSHIFT_ROOT_LOCAL_FILE
+        $JAVA_HOME/bin/keytool -import -trustcacerts -alias $REDSHIFT_ROOT_ALIAS -storepass $JAVA_KEYSTORE_PASSWORD -noprompt -keystore $JAVA_KEYSTORE_FILE -file $REDSHIFT_ROOT_LOCAL_FILE
         if [ $? -ne 0 ]; then
-                echo "ERROR: Could not install Redshift root certificate!"
+                echo "ERROR: Could not install Redshift certificate bundle!"
                 exit 1
         fi
-        echo 'Redshift root certificate installed successfully!'
+        echo 'Redshift certificate bundle installed successfully!'


### PR DESCRIPTION
The redshift-ssl-java.config .ebextension relied on the old Redshift SSL certificate that is expiring on 10/23.  This change updates the .ebextension to use the new certificate bundle.