### PR TITLE
fix chmod before mount

### DIFF
--- a/configuration-files/aws-provided/instance-configuration/storage-efs-mountfilesystem.config
+++ b/configuration-files/aws-provided/instance-configuration/storage-efs-mountfilesystem.config
@@ -79,10 +79,6 @@ files:
                 echo 'ERROR: Directory creation failed!'
                 exit 1
             fi
-            if [ $? -ne 0 ]; then
-                echo 'ERROR: Permission update failed!'
-                exit 1
-            fi
         else
             echo "Directory ${EFS_MOUNT_DIR} already exists!"
         fi

--- a/configuration-files/aws-provided/instance-configuration/storage-efs-mountfilesystem.config
+++ b/configuration-files/aws-provided/instance-configuration/storage-efs-mountfilesystem.config
@@ -79,7 +79,6 @@ files:
                 echo 'ERROR: Directory creation failed!'
                 exit 1
             fi
-            chmod 777 ${EFS_MOUNT_DIR}
             if [ $? -ne 0 ]; then
                 echo 'ERROR: Permission update failed!'
                 exit 1
@@ -96,6 +95,14 @@ files:
                 echo 'ERROR: Mount command failed!'
                 exit 1
             fi
+            chmod 777 ${EFS_MOUNT_DIR}
+            runuser -l  ec2-user -c "touch ${EFS_MOUNT_DIR}/it_works"
+                if [[ $? -ne 0 ]]; then
+                    echo 'ERROR: Permission Error!'
+                    exit 1
+                else
+                    runuser -l  ec2-user -c "rm -f ${EFS_MOUNT_DIR}/it_works"
+                fi
         else
             echo "Directory ${EFS_MOUNT_DIR} is already a valid mountpoint!"
         fi

--- a/configuration-files/aws-provided/instance-configuration/storage-efs-mountfilesystem.config
+++ b/configuration-files/aws-provided/instance-configuration/storage-efs-mountfilesystem.config
@@ -93,12 +93,12 @@ files:
             fi
             chmod 777 ${EFS_MOUNT_DIR}
             runuser -l  ec2-user -c "touch ${EFS_MOUNT_DIR}/it_works"
-                if [[ $? -ne 0 ]]; then
-                    echo 'ERROR: Permission Error!'
-                    exit 1
-                else
-                    runuser -l  ec2-user -c "rm -f ${EFS_MOUNT_DIR}/it_works"
-                fi
+            if [[ $? -ne 0 ]]; then
+                echo 'ERROR: Permission Error!'
+                exit 1
+            else
+                runuser -l  ec2-user -c "rm -f ${EFS_MOUNT_DIR}/it_works"
+            fi
         else
             echo "Directory ${EFS_MOUNT_DIR} is already a valid mountpoint!"
         fi


### PR DESCRIPTION
After running the command MOUNT the UID:GID and permissions of the mount point are set to ones from the root directory of the mounted partition. This behavior overwrites the previous chmod 777, on line 82, which makes sense move the permission grant after the mount command and also test if a non-root user has permission to write on the mounted EFS path.

Feel totally free to reject/change this PR if you don't think it's helpful to other people.