### PR TITLE
Remove Listen 443 because its already used in ssl.conf and causes issues

### DIFF
--- a/configuration-files/aws-provided/security-configuration/https-instancecert/https-instancecert-php.config
+++ b/configuration-files/aws-provided/security-configuration/https-instancecert/https-instancecert-php.config
@@ -46,7 +46,6 @@ files:
     group: root
     content: |
       LoadModule ssl_module modules/mod_ssl.so
-      Listen 443
       <VirtualHost *:443>
         <Proxy *>
           Order deny,allow


### PR DESCRIPTION
I believe I ran in to this bug [here](https://bugs.centos.org/view.php?id=10847). The ssl.conf already on the server has `Listen 443 https` and I had to remove `Listen 443` from the https.conf for everything to work.