### PR TITLE
Chown EFS directory for webapp user

### DIFF
--- a/configuration-files/aws-provided/instance-configuration/storage-efs-mountfilesystem.config
+++ b/configuration-files/aws-provided/instance-configuration/storage-efs-mountfilesystem.config
@@ -27,6 +27,9 @@
 #### DNS resolution and DNS host names. See this topic in the VPC User Guide for more information:
 ####    http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/vpc-dns.html
 ###################################################################################################
+container_commands:
+  01_chown:
+    command: "chown webapp:webapp /efs"
 
 option_settings:
   aws:elasticbeanstalk:application:environment:


### PR DESCRIPTION
I tried this config file but my webapp user was not able to write to the efs directory. Adding the `chown` command solved that issue for me. Can you confirm that?